### PR TITLE
More responsive!

### DIFF
--- a/src/coffee/Tabbie.coffee
+++ b/src/coffee/Tabbie.coffee
@@ -311,9 +311,14 @@ class Tabbie
       , (granted) =>
         if granted
           drawer = document.querySelector "app-drawer.bookmarks"
-          drawer.show()
-          drawer.addEventListener "opened-changed", ->
-            if @opened then settings.classList.add("force") else settings.classList.remove("force")
+         otherdrawers=[document.querySelector "app-drawer.bookmarks",document.querySelector("app-drawer.apps")]
+            drawer.innerHTML = ""
+            drawer.show()
+            drawer.addEventListener "opened-changed", ->
+              if @opened then settings.classList.add("force") else
+                for otherdrawer in otherdrawers
+                  otherdrawer.addEventListener "opened-changed", ->
+                    if @opened then settings.classList.add("force") else settings.classList.remove("force")
 
           chrome.bookmarks.getRecent 20, (tree) =>
             console.log tree
@@ -339,10 +344,14 @@ class Tabbie
           chrome.topSites.get (sites) =>
             console.log sites
             drawer = document.querySelector("app-drawer.top")
+            otherdrawers=[document.querySelector "app-drawer.bookmarks",document.querySelector("app-drawer.apps")]
             drawer.innerHTML = ""
             drawer.show()
             drawer.addEventListener "opened-changed", ->
-              if @opened then settings.classList.add("force") else settings.classList.remove("force")
+              if @opened then settings.classList.add("force") else
+                for otherdrawer in otherdrawers
+                  otherdrawer.addEventListener "opened-changed", ->
+                    if @opened then settings.classList.add("force") else settings.classList.remove("force")
             for site in sites
               paper = document.createElement "bookmark-item"
               paper.showdate = false
@@ -359,10 +368,14 @@ class Tabbie
           if granted
             chrome.management.getAll (extensions) =>
               drawer = document.querySelector("app-drawer.apps")
-              drawer.innerHTML = ""
-              drawer.show()
-              drawer.addEventListener "opened-changed", ->
-                if @opened then settings.classList.add("force") else settings.classList.remove("force")
+             otherdrawers=[document.querySelector "app-drawer.bookmarks",document.querySelector("app-drawer.apps")]
+            drawer.innerHTML = ""
+            drawer.show()
+            drawer.addEventListener "opened-changed", ->
+              if @opened then settings.classList.add("force") else
+                for otherdrawer in otherdrawers
+                  otherdrawer.addEventListener "opened-changed", ->
+                    if @opened then settings.classList.add("force") else settings.classList.remove("force")
 
               for extension in extensions when extension.type.indexOf("app") isnt -1 and not extension.disabled
                 console.log extension

--- a/src/item-column.html
+++ b/src/item-column.html
@@ -99,12 +99,8 @@
                 overflow: auto;
             }
             body {
-                position: absolute;
-                top: 20px;
-                left: 20px;
-                bottom: 20px;
-                right: 20px;
-                padding: 30px;
+                display:inline-block;
+                float:left;
                 overflow-y: scroll;
                 overflow-x: hidden;
             }


### PR DESCRIPTION
More responsive & Bug Fixed in Settings(drawer-button)!
Whenever I reduce screen size, tabs start overlapping each other,because of absolute positioning. I guess this update will fix it.

Bug Fixed in Settings(drawer-button)!
When i click on another drawer button in an already opened settings window,it gets closed.I made an array of two other drawer button and looped through them thus if they get clicked,it still remains opened.I'm not comfortable with cofeescript,so have look over my code.
